### PR TITLE
Bind datadog services to the local loopback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
- && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: no/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -185,7 +185,3 @@ if [[ $DOGSTATSD_ONLY ]]; then
 else
 		exec "$@"
 fi
-
-##### Add DNS servers to resolv.conf ######
-echo -e "nameserver 8.8.8.8 8.8.4.4\n$(cat /etc/resolv.conf)" > /etc/resolv.conf
-echo -e "nameserver 8.8.8.8 8.8.4.4\n$(cat /etc/resolv.conf)" > /resolv.conf


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Binds all datadog services to the loopback interface.

### Motivation

The only method we've found to access the host's network information(interface statistics) via a container is to provider the container with net=host.

### Testing Guidelines

Run the container and verify that the services are operating, while only bound to 127.0.0.1.

### Additional Notes

We have yet to test this on any proper environment.